### PR TITLE
Add support for hdfs ha config

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ buildRpm.enabled = false
 
 ospackage {
 	version = '1.2'
-	release = 2
+	release = 3
 	arch = NOARCH
 	os = LINUX
 	user 'root'

--- a/src/main/resources/services/SPRINGXD/package/scripts/params.py
+++ b/src/main/resources/services/SPRINGXD/package/scripts/params.py
@@ -60,6 +60,19 @@ springxd_container_env_sh_template = config['configurations']['springxd-containe
 springxd_user = config['configurations']['springxd-admin-env']['springxd_user']
 springxd_hdfs_user_dir = format("/user/{springxd_user}")
 
+# hdfs ha
+dfs_ha_enabled = False
+dfs_ha_nameservices = default("/configurations/hdfs-site/dfs.nameservices", None)
+dfs_ha_namenode_ids = default(format("/configurations/hdfs-site/dfs.ha.namenodes.{dfs_ha_nameservices}"), None)
+dfs_ha_automatic_failover_enabled = default("/configurations/hdfs-site/dfs.ha.automatic-failover.enabled", False)
+dfs_ha_namemodes_ids_list = []
+
+if dfs_ha_namenode_ids:
+  dfs_ha_namemodes_ids_list = dfs_ha_namenode_ids.split(",")
+  dfs_ha_namenode_ids_array_len = len(dfs_ha_namemodes_ids_list)
+  if dfs_ha_namenode_ids_array_len > 1:
+    dfs_ha_enabled = True
+
 # cluster configs
 kafka_port = config['configurations']['kafka-broker']['port']
 zk_port = config['configurations']['zoo.cfg']['clientPort']

--- a/src/main/resources/services/SPRINGXD/package/scripts/springxd.py
+++ b/src/main/resources/services/SPRINGXD/package/scripts/springxd.py
@@ -54,6 +54,12 @@ def springxd(name = None):
             recursive=True
   )
 
+  dfs_ha_map = {}
+  if params.dfs_ha_enabled:
+    for nn_id in params.dfs_ha_namemodes_ids_list:
+      nn_host = params.config['configurations']['hdfs-site'][format('dfs.namenode.rpc-address.{dfs_ha_nameservices}.{nn_id}')]
+      dfs_ha_map[nn_id] = nn_host
+
   configurations = params.config['configurations']['springxd-site']
   sec_filtered_map = {}
   for key,value in configurations.iteritems():
@@ -69,7 +75,8 @@ def springxd(name = None):
   )
 
   File(format("{conf_dir}/xd-shell.init"),
-       content=Template("xd-shell.init.j2"),
+       content=Template("xd-shell.init.j2",
+                        dfs_ha_map = dfs_ha_map),
        owner=params.springxd_user,
        group=params.user_group
   )
@@ -88,6 +95,7 @@ def springxd(name = None):
 
   File(format("{conf_dir}/hadoop.properties"),
        content=Template("hadoop.properties.j2",
+                        dfs_ha_map = dfs_ha_map,
                         sec_filtered_map = sec_filtered_map),
        owner=params.springxd_user,
        group=params.user_group

--- a/src/main/resources/services/SPRINGXD/package/templates/hadoop.properties.j2
+++ b/src/main/resources/services/SPRINGXD/package/templates/hadoop.properties.j2
@@ -8,3 +8,12 @@ spring.hadoop.security.namenodePrincipal={{nn_principal_name}}
 spring.hadoop.security.rmManagerPrincipal={{rm_principal_name}}
 spring.hadoop.security.jobHistoryPrincipal={{jhs_principal_name}}
 {% endif %}
+{% if dfs_ha_enabled %}
+dfs.ha.automatic-failover.enabled={{dfs_ha_automatic_failover_enabled}}
+dfs.nameservices={{dfs_ha_nameservices}}
+dfs.client.failover.proxy.provider.mycluster=org.apache.hadoop.hdfs.server.namenode.ha.ConfiguredFailoverProxyProvider
+dfs.ha.namenodes.{{dfs_ha_nameservices}}={{dfs_ha_namenode_ids}}
+{% for key, value in dfs_ha_map.iteritems() %}
+dfs.namenode.rpc-address.{{dfs_ha_nameservices}}.{{key}}={{value}}
+{% endfor %}
+{% endif %}

--- a/src/main/resources/services/SPRINGXD/package/templates/xd-shell.init.j2
+++ b/src/main/resources/services/SPRINGXD/package/templates/xd-shell.init.j2
@@ -1,3 +1,12 @@
 admin config server {{xd_shell_admin_server_address}}
 hadoop config fs --namenode {{xd_shell_hdfs_address}}
+{% if dfs_ha_enabled %}
+hadoop config props set --property dfs.ha.automatic-failover.enabled={{dfs_ha_automatic_failover_enabled}}
+hadoop config props set --property dfs.nameservices={{dfs_ha_nameservices}}
+hadoop config props set --property dfs.client.failover.proxy.provider.mycluster=org.apache.hadoop.hdfs.server.namenode.ha.ConfiguredFailoverProxyProvider
+hadoop config props set --property dfs.ha.namenodes.{{dfs_ha_nameservices}}={{dfs_ha_namenode_ids}}
+{% for key, value in dfs_ha_map.iteritems() %}
+hadoop config props set --property dfs.namenode.rpc-address.{{dfs_ha_nameservices}}.{{key}}={{value}}
+{% endfor %}
+{% endif %}
 


### PR DESCRIPTION
- relates to #6
- we basically detect if namenode ha is enabled which in
  ambari is done via a wizard after an initial cluster
  provisioning.
- we modify both hadoop.properties and xd-shell.init for below
  settings(I named my ha as 'mycluster'):

dfs.ha.automatic-failover.enabled=True

dfs.nameservices=mycluster

dfs.client.failover.proxy.provider.mycluster=org.apache.hadoop.hdfs.server.namenode.ha.ConfiguredFailoverProxyProvider

dfs.ha.namenodes.mycluster=nn1,nn2

dfs.namenode.rpc-address.mycluster.nn2=ambari-3.localdomain:8020

dfs.namenode.rpc-address.mycluster.nn1=ambari-2.localdomain:8020
