### PR TITLE
Resolve #Issue-5: HDP2.3 & Ambari 2.1 Support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,14 @@ task hdp22Rpm(type: Rpm) {
 	}
 }
 
+task hdp23Rpm(type: Rpm) {
+        packageName = 'spring-xd-plugin-hdp23'
+        from('src/main/resources/services') {
+                into '/var/lib/ambari-server/resources/stacks/HDP/2.3/services'
+        }
+}
+
 task dist {
-	dependsOn phd30Rpm, hdp22Rpm
+	dependsOn phd30Rpm, hdp22Rpm, hdp23Rpm
 }
 

--- a/src/main/package/rpm/postinstall.sh
+++ b/src/main/package/rpm/postinstall.sh
@@ -43,10 +43,23 @@ elif os.path.exists('/var/lib/ambari-server/resources/stacks/HDP/2.2/role_comman
   json.dump(data, json_data, indent=2)
   json_data.close() 
 
+if os.path.exists('/var/lib/ambari-server/resources/stacks/HDP/2.3/role_command_order.json'):
+  json_data=open('/var/lib/ambari-server/resources/stacks/HDP/2.3/role_command_order.json', 'r+')
+  data = json.load(json_data)
+  data['general_deps']['SPRINGXD-INSTALL'] = ['HDFS-INSTALL']
+  data['general_deps']['SPRINGXDADMIN-START'] = ['SPRINGXDHSQL-START','ZOOKEEPER_SERVER-START','KAFKA_BROKER-START','NODEMANAGER-START','RESOURCEMANAGER-START']
+  data['general_deps']['SPRINGXDCONTAINER-START'] = ['SPRINGXDHSQL-START','ZOOKEEPER_SERVER-START','KAFKA_BROKER-START','NODEMANAGER-START','RESOURCEMANAGER-START']
+  json_data.seek(0)
+  json.dump(data, json_data, indent=2)
+  json_data.close()
+
 if os.path.exists('/var/lib/ambari-server/resources/stacks/PHD/3.0/repos/repoinfo.xml'):
   updateRepoWithSpringXd('/var/lib/ambari-server/resources/stacks/PHD/3.0/repos/repoinfo.xml')
 elif os.path.exists('/var/lib/ambari-server/resources/stacks/HDP/2.2/repos/repoinfo.xml'):
   updateRepoWithSpringXd('/var/lib/ambari-server/resources/stacks/HDP/2.2/repos/repoinfo.xml')
+
+if os.path.exists('/var/lib/ambari-server/resources/stacks/HDP/2.3/repos/repoinfo.xml'):
+  updateRepoWithSpringXd('/var/lib/ambari-server/resources/stacks/HDP/2.3/repos/repoinfo.xml')
 
 EOT
 

--- a/src/main/package/rpm/preremove.sh
+++ b/src/main/package/rpm/preremove.sh
@@ -48,10 +48,29 @@ elif os.path.exists('/var/lib/ambari-server/resources/stacks/HDP/2.2/role_comman
   json.dump(data, json_data, indent=2)
   json_data.close()
 
+if os.path.exists('/var/lib/ambari-server/resources/stacks/HDP/2.3/role_command_order.json'):
+  json_data=open('/var/lib/ambari-server/resources/stacks/HDP/2.3/role_command_order.json', 'r+')
+  data = json.load(json_data)
+  if data['general_deps'].has_key('SPRINGXD-INSTALL'):
+    data['general_deps'].pop('SPRINGXD-INSTALL')
+  if data['general_deps'].has_key('SPRINGXDADMIN-START'):
+    data['general_deps'].pop('SPRINGXDADMIN-START')
+  if data['general_deps'].has_key('SPRINGXDCONTAINER-START'):
+    data['general_deps'].pop('SPRINGXDCONTAINER-START')
+  json_data.seek(0)
+  json_data.truncate()
+  json.dump(data, json_data, indent=2)
+  json_data.close()
+
 if os.path.exists('/var/lib/ambari-server/resources/stacks/PHD/3.0/repos/repoinfo.xml'):
   updateRepoWithSpringXd('/var/lib/ambari-server/resources/stacks/PHD/3.0/repos/repoinfo.xml')
 elif os.path.exists('/var/lib/ambari-server/resources/stacks/HDP/2.2/repos/repoinfo.xml'):
   updateRepoWithSpringXd('/var/lib/ambari-server/resources/stacks/HDP/2.2/repos/repoinfo.xml')
+
+if os.path.exists('/var/lib/ambari-server/resources/stacks/HDP/2.3/repos/repoinfo.xml'):
+  updateRepoWithSpringXd('/var/lib/ambari-server/resources/stacks/HDP/2.3/repos/repoinfo.xml')
+
+
 
 EOT
 

--- a/src/main/resources/services/SPRINGXD/package/scripts/params.py
+++ b/src/main/resources/services/SPRINGXD/package/scripts/params.py
@@ -152,13 +152,38 @@ if security_enabled:
   user_keytab = config['configurations']['springxd-site']['spring.hadoop.security.userKeytab']
 
 import functools
-HdfsDirectory = functools.partial(
-  HdfsDirectory,
-  conf_dir=hadoop_conf_dir,
-  hdfs_user=hdfs_user,
-  security_enabled = security_enabled,
-  keytab = hdfs_user_keytab,
-  kinit_path_local = kinit_path_local,
-  bin_dir = hadoop_bin_dir
-)
 
+HdfsDirectory = None
+
+hdfs_site = config['configurations']['hdfs-site']
+default_fs = config['configurations']['core-site']['fs.defaultFS']
+
+action_create_delayed = "create_delayed"
+action_create = "create"
+
+if stack_name == 'hdp' and stack_version.startswith('2.3'):
+    action_create_delayed = "create_on_execute"
+    action_create = "execute"
+    HdfsDirectory = functools.partial(
+        HdfsResource,
+        type="directory",
+        user=hdfs_user,
+        security_enabled = security_enabled,
+        keytab = hdfs_user_keytab,
+        kinit_path_local = kinit_path_local,
+        hadoop_bin_dir = hadoop_bin_dir,
+        hadoop_conf_dir = hadoop_conf_dir,
+        principal_name = hdfs_principal_name,
+        hdfs_site = hdfs_site,
+        default_fs = default_fs
+        )
+else: 
+    HdfsDirectory = functools.partial(
+        HdfsDirectory,
+        conf_dir=hadoop_conf_dir,
+        hdfs_user=hdfs_user,
+        security_enabled = security_enabled,
+        keytab = hdfs_user_keytab,
+        kinit_path_local = kinit_path_local,
+        bin_dir = hadoop_bin_dir
+        )

--- a/src/main/resources/services/SPRINGXD/package/scripts/springxd.py
+++ b/src/main/resources/services/SPRINGXD/package/scripts/springxd.py
@@ -30,16 +30,16 @@ def springxd(name = None):
 
   if name == "admin":
     params.HdfsDirectory("/xd",
-                         action="create_delayed",
+                         action=params.action_create_delayed,
                          owner=params.springxd_user,
                          mode=0777
     )
     params.HdfsDirectory(params.springxd_hdfs_user_dir,
-                         action="create_delayed",
+                         action=params.action_create_delayed,
                          owner=params.springxd_user,
                          mode=0777
     )
-    params.HdfsDirectory(None, action="create")
+    params.HdfsDirectory(None, action=params.action_create)
 
   Directory(params.log_dir,
             owner=params.springxd_user,


### PR DESCRIPTION
```
./gradlew clean dist
```

produces a new rpm artefact: `spring-xd-plugin-hdp23-1.2-2.noarch.rpm`

Summary:
- Add new build artefact: `spring-xd-plugin-hdp23` and build task: `hdp23Rpm`
- Extend the postinstall.sh and preremove.sh to support HDP/2.3 repository structure. NOTE that you could have multiple Stacks installed at the same time. It is not mutually excluding either PHD or HDP or ..
- Ambari 2.1 replaces `HdfsDirectory` by `HdfsResource`. I've modified to params.py and springxd.py to support the new API and still provide backaward compatibility
