### PR TITLE
Issue-22: Expose the management and monitoring enable/disable properties

### DIFF
--- a/src/main/resources/services/SPRINGXD/configuration/springxd-site.xml
+++ b/src/main/resources/services/SPRINGXD/configuration/springxd-site.xml
@@ -63,4 +63,10 @@
     <description>HSQL server port</description>
   </property>
 
+  <property>
+    <name>xd.management.enabled</name>
+    <value>false</value>
+    <description>XD Enable JMX and the management metrics</description>
+  </property>
+
 </configuration>

--- a/src/main/resources/services/SPRINGXD/package/scripts/params.py
+++ b/src/main/resources/services/SPRINGXD/package/scripts/params.py
@@ -41,6 +41,7 @@ java64_home = config['hostLevelParams']['java_home']
 jps_binary = format("{java64_home}/bin/jps")
 
 # xd configs
+xd_management_enabled = config['configurations']['springxd-site']['xd.management.enabled']
 xd_transport = config['configurations']['springxd-site']['xd.transport'].strip()
 xd_custommodule_home = config['configurations']['springxd-site']['xd.customModule.home'].strip()
 hsql_port = config['configurations']['springxd-site']['hsql.server.port']

--- a/src/main/resources/services/SPRINGXD/package/templates/servers.yml.j2
+++ b/src/main/resources/services/SPRINGXD/package/templates/servers.yml.j2
@@ -84,6 +84,30 @@ spring:
     validationQuery: select 1 from INFORMATION_SCHEMA.SYSTEM_USERS
 {% endif %}
 
+{% if xd_management_enabled %}
+---
+# Config to enable/disable JMX/jolokia endpoints
+XD_JMX_ENABLED: true
+endpoints:
+  jolokia:
+    enabled: ${XD_JMX_ENABLED:false}
+  jmx:
+    enabled: ${XD_JMX_ENABLED:false}
+    uniqueNames: true
+
+---
+#Enable collecting message rates from containers that have management port enabled.
+xd:
+  messageRateMonitoring:
+    enabled: true
+
+---
+spring:
+  profiles: container
+management:
+  port: 0
+{% endif %}
+
 ---
 spring:
   hadoop:


### PR DESCRIPTION
Address: #22 
Expose a single aggregated property (xd.management.enabled) which when set to true enables:

```
XD_JMX_ENABLED: true
endpoints:
  jolokia:
    enabled: ${XD_JMX_ENABLED:false}
  jmx:
    enabled: ${XD_JMX_ENABLED:false}
    uniqueNames: true

---
xd:
  messageRateMonitoring:
    enabled: true

---
spring:
  profiles: container
management:
  port: 0
```
