### PR TITLE
URL Cleanup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <artifactId>springxd-plugin</artifactId>
   <version>1.2</version>
   <name>spring-plugin</name>
-  <url>http://maven.apache.org</url>
+  <url>https://maven.apache.org</url>
 
   <properties>
     <base.dir>/var/lib/ambari-server/resources/stacks</base.dir>

--- a/src/main/package/rpm/postinstall.sh
+++ b/src/main/package/rpm/postinstall.sh
@@ -7,7 +7,7 @@ from pprint import pprint
 
 def updateRepoWithSpringXd(repoinfoxml):
   springxd_repo='Spring-XD-1.3'
-  springxd_repo_str = '<repo><baseurl>http://repo.spring.io/yum-release/spring-xd/1.3</baseurl><repoid>' + springxd_repo + '</repoid><reponame>' + springxd_repo + '</reponame></repo>'
+  springxd_repo_str = '<repo><baseurl>https://repo.spring.io/yum-release/spring-xd/1.3</baseurl><repoid>' + springxd_repo + '</repoid><reponame>' + springxd_repo + '</reponame></repo>'
   is_springxdrepo_set = None
 
   tree = ET.parse(repoinfoxml)


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were fixed successfully.

* http://maven.apache.org migrated to:  
  https://maven.apache.org ([https](https://maven.apache.org) result 200).
* http://repo.spring.io/yum-release/spring-xd/1.3 migrated to:  
  https://repo.spring.io/yum-release/spring-xd/1.3 ([https](https://repo.spring.io/yum-release/spring-xd/1.3) result 302).

# Ignored
These URLs were intentionally ignored.

* http://maven.apache.org/POM/4.0.0
* http://maven.apache.org/maven-v4_0_0.xsd
* http://www.w3.org/2001/XMLSchema-instance