### PR TITLE
URL Cleanup

### DIFF
--- a/src/docs/asciidoc/InstallingHDPwithAmbari.asciidoc
+++ b/src/docs/asciidoc/InstallingHDPwithAmbari.asciidoc
@@ -15,21 +15,21 @@ For Ambari 1.7.0 use:
 
 [source]
 ----
-wget -nv http://public-repo-1.hortonworks.com/ambari/centos6/1.x/updates/1.7.0/ambari.repo -O /etc/yum.repos.d/ambari.repo
+wget -nv https://public-repo-1.hortonworks.com/ambari/centos6/1.x/updates/1.7.0/ambari.repo -O /etc/yum.repos.d/ambari.repo
 ----
 
 For Ambari 2.0.x use:
 
 [source]
 ----
-wget -nv http://public-repo-1.hortonworks.com/ambari/centos6/2.x/updates/2.0.1/ambari.repo -O /etc/yum.repos.d/ambari.repo
+wget -nv https://public-repo-1.hortonworks.com/ambari/centos6/2.x/updates/2.0.1/ambari.repo -O /etc/yum.repos.d/ambari.repo
 ----
 
 For Ambari 2.1.x use:
 
 [source]
 ----
-wget -nv http://public-repo-1.hortonworks.com/ambari/centos6/2.x/updates/2.1.2.1/ambari.repo -O /etc/yum.repos.d/ambari.repo
+wget -nv https://public-repo-1.hortonworks.com/ambari/centos6/2.x/updates/2.1.2.1/ambari.repo -O /etc/yum.repos.d/ambari.repo
 ----
 
 Check that we have the Ambari repo listed as part of YUM repos:

--- a/src/docs/asciidoc/InstallingPHDwithAmbari.asciidoc
+++ b/src/docs/asciidoc/InstallingPHDwithAmbari.asciidoc
@@ -7,11 +7,11 @@ First we need a VM to work with. Follow the instructions in link:PreparingVMforA
 
 == Installing Ambari Server
 
-We can follow steps 2.2 through 2.8 from the link:http://pivotalhd.docs.pivotal.io/docs/install-ambari.html#installing-ambari-server[Pivotal Ambari Installation Guide]
+We can follow steps 2.2 through 2.8 from the link:https://pivotalhd.docs.pivotal.io/docs/install-ambari.html#installing-ambari-server[Pivotal Ambari Installation Guide]
 
 == Create Hadoop Cluster
 
-We can follow steps 3.2 through 3.6 from the link:http://pivotalhd.docs.pivotal.io/docs/install-ambari.html#install-cluster[Pivotal Ambari Installation Guide]
+We can follow steps 3.2 through 3.6 from the link:https://pivotalhd.docs.pivotal.io/docs/install-ambari.html#install-cluster[Pivotal Ambari Installation Guide]
 
 I installed the PHD-3.0.0.0 and PHD-UTILS-1.1.0 stacks.
 
@@ -19,8 +19,8 @@ My Repository settings are (`hawaii` is the hostname for my YUM repo machine):
 
 [width="80%",cols="1m,3m,6m",frame="topbot"]
 |=====================================
-|redhat6 |PHD-3.0             |http://hawaii/PHD-3.0.0.0
-|        |PHD-UTILS-1.1.0.20  |http://hawaii/PHD-UTILS-1.1.0.20
+|redhat6 |PHD-3.0             |https://hawaii/PHD-3.0.0.0
+|        |PHD-UTILS-1.1.0.20  |https://hawaii/PHD-UTILS-1.1.0.20
 |=====================================
 
 I configured my single-node VMs hostname as the only host.

--- a/src/docs/asciidoc/InstallingXDwithAmbari.asciidoc
+++ b/src/docs/asciidoc/InstallingXDwithAmbari.asciidoc
@@ -1,7 +1,7 @@
 Installing Spring XD using Ambari
 =================================
 
-These instructions apply to an installation using link:http://pivotalhd.docs.pivotal.io/docs/install-ambari.html[Pivotal Ambari] as well as link:http://docs.hortonworks.com/HDPDocuments/Ambari-2.0.1.0/index.html[Hortonworks Ambari] using Red Hat Enterprise Linux 6.5 or CentOS 6.5. 
+These instructions apply to an installation using link:https://pivotalhd.docs.pivotal.io/docs/install-ambari.html[Pivotal Ambari] as well as link:https://docs.hortonworks.com/HDPDocuments/Ambari-2.0.1.0/index.html[Hortonworks Ambari] using Red Hat Enterprise Linux 6.5 or CentOS 6.5. 
 
 NOTE: These instructions are for *Spring XD version 1.3.1*. Instructions for Spring XD 1.2.x can be found link:https://github.com/spring-projects/spring-xd-ambari/blob/1a229c77af5df6c063546c9d6f6dc1f1e9285052/src/docs/asciidoc/InstallingXDwithAmbari.asciidoc[here].
 
@@ -81,7 +81,7 @@ We need to copy the Spring XD repository definition into the local YUM repositor
 
 [source]
 ----
-# wget -nv http://repo.spring.io/yum-release/spring-xd/1.3/spring-xd-1.3.repo -O /etc/yum.repos.d/spring-xd-1.3.repo
+# wget -nv https://repo.spring.io/yum-release/spring-xd/1.3/spring-xd-1.3.repo -O /etc/yum.repos.d/spring-xd-1.3.repo
 ----
 
 Check that the Spring XD YUM repo is available using:
@@ -116,13 +116,13 @@ We now need to restart the Ambari server to pick up this new plugin:
 
 === Install Redis 
 
-You can build Redis from source or you can use RPMs that are available from the link:https://fedoraproject.org/wiki/EPEL[EPEL] project. Source is available from the link:http://redis.io/download[Redis download] page. Here we'll use the RPM packages. 
+You can build Redis from source or you can use RPMs that are available from the link:https://fedoraproject.org/wiki/EPEL[EPEL] project. Source is available from the link:https://redis.io/download[Redis download] page. Here we'll use the RPM packages. 
 
 We need to add a Fedora YUM repo for Redis and then install it:
 
 [source]
 ----
-# wget http://dl.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm
+# wget https://dl.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm
 # rpm -Uvh epel-release-6*.rpm
 # yum -y install redis
 # chkconfig redis on
@@ -159,7 +159,7 @@ We need to have a transport installed and we can use the Redis instance that we 
 
 ==== Using Kafka as Transport
 
-Hortonworks HDP supports Kafka installs using Ambari while Pivotal PHD does not. If you use Hortonworks HDP then you should create a Kafka service using Ambari. If you use Pivotal PHD then you need to install Kafka manually first and provide the connection parameters when you create the Spring XD service. Kafka can be downloaded from the link:http://kafka.apache.org/downloads.html[Kafka download] page.
+Hortonworks HDP supports Kafka installs using Ambari while Pivotal PHD does not. If you use Hortonworks HDP then you should create a Kafka service using Ambari. If you use Pivotal PHD then you need to install Kafka manually first and provide the connection parameters when you create the Spring XD service. Kafka can be downloaded from the link:https://kafka.apache.org/downloads.html[Kafka download] page.
 
 ==== Using RabbitMQ as Transport
 
@@ -167,7 +167,7 @@ You need to install RabbitMQ manually. You can get more complete instructions fr
 
 [source]
 ----
-# rpm -Uvh http://download.fedoraproject.org/pub/epel/6/i386/epel-release-6-8.noarch.rpm
+# rpm -Uvh https://download.fedoraproject.org/pub/epel/6/i386/epel-release-6-8.noarch.rpm
 # yum install erlang
 # rpm --import https://www.rabbitmq.com/rabbitmq-signing-key-public.asc
 # wget https://www.rabbitmq.com/releases/rabbitmq-server/v3.5.3/rabbitmq-server-3.5.3-1.noarch.rpm
@@ -195,7 +195,7 @@ Open the Ambari UI and log in as `admin`. Select `Admin` -> `Repositories` from 
 
 [width="80%",cols="1m,2m,6m",frame="topbot"]
 |=====================================
-|redhat6 |SPRINGXD-1.3        |http://repo.spring.io/yum-release/spring-xd/1.3/
+|redhat6 |SPRINGXD-1.3        |https://repo.spring.io/yum-release/spring-xd/1.3/
 |=====================================
 
 === Install Spring XD and create Spring XD service using Ambari UI

--- a/src/docs/asciidoc/PreparingVMforAmbari.asciidoc
+++ b/src/docs/asciidoc/PreparingVMforAmbari.asciidoc
@@ -13,7 +13,7 @@ Once you have VirtualBox installed and up and running we can create our virtual 
 
 === Create a CentOS VM
 
-You can download the Centos 6.5 64-bit ISO from one of the mirrors at link:http://mirror.centos.org/centos/6/isos/x86_64/[http://mirror.centos.org/centos/6/isos/x86_64/].
+You can download the Centos 6.5 64-bit ISO from one of the mirrors at link:http://isoredirect.centos.org/centos/6/isos/x86_64/[http://isoredirect.centos.org/centos/6/isos/x86_64/].
 
 Create a new VM with 8GB of memory and 60GB of disk space if you have this available. You can try allocating only 4GB of memory if you are low on resources. Before starting the VM, attach the Live CD image you downloaded to the CD/DVD drive of the new VM. You should also create two network adapters, "Adapter 1" set to "Host-only Adapter" and "Adapter 2" using "NAT" (If you haven't already created a "Host-only Network", you should do that first, under the VirtualBox Preferences Network tab). 
 

--- a/src/docs/asciidoc/UpgradingXDwithAmbari.asciidoc
+++ b/src/docs/asciidoc/UpgradingXDwithAmbari.asciidoc
@@ -1,7 +1,7 @@
 Upgrading to Spring XD 1.3.1.RELEASE using Ambari
 =================================================
 
-These instructions apply to an installation using link:http://pivotalhd.docs.pivotal.io/docs/install-ambari.html[Pivotal Ambari] as well as link:http://docs.hortonworks.com/HDPDocuments/Ambari-2.0.1.0/index.html[Hortonworks Ambari] using Red Hat Enterprise Linux 6.5 or CentOS 6.5. 
+These instructions apply to an installation using link:https://pivotalhd.docs.pivotal.io/docs/install-ambari.html[Pivotal Ambari] as well as link:https://docs.hortonworks.com/HDPDocuments/Ambari-2.0.1.0/index.html[Hortonworks Ambari] using Red Hat Enterprise Linux 6.5 or CentOS 6.5. 
 
 This document describes the upgrade process. For initial installation instructions please refer to link:InstallingXDwithAmbari.asciidoc[Installing Spring XD using Ambari].
 
@@ -18,7 +18,7 @@ Log in as `root` on each node.
 Add the new Spring XD 1.3 YUM repo:
 [source,bash]
 ----
-wget -nv http://repo.spring.io/yum-release/spring-xd/1.3/spring-xd-1.3.repo -O /etc/yum.repos.d/spring-xd-1.3.repo
+wget -nv https://repo.spring.io/yum-release/spring-xd/1.3/spring-xd-1.3.repo -O /etc/yum.repos.d/spring-xd-1.3.repo
 ----
 
 Perform a regular YUM update operation:


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* [ ] http://mirror.centos.org/centos/6/isos/x86_64/ (302) with 2 occurrences could not be migrated:  
   ([https](https://mirror.centos.org/centos/6/isos/x86_64/) result AnnotatedConnectException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://hawaii/PHD-3.0.0.0 (UnknownHostException) with 1 occurrences migrated to:  
  https://hawaii/PHD-3.0.0.0 ([https](https://hawaii/PHD-3.0.0.0) result UnknownHostException).
* [ ] http://hawaii/PHD-UTILS-1.1.0.20 (UnknownHostException) with 1 occurrences migrated to:  
  https://hawaii/PHD-UTILS-1.1.0.20 ([https](https://hawaii/PHD-UTILS-1.1.0.20) result UnknownHostException).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://dl.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm with 1 occurrences migrated to:  
  https://dl.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm ([https](https://dl.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm) result 200).
* [ ] http://docs.hortonworks.com/HDPDocuments/Ambari-2.0.1.0/index.html with 2 occurrences migrated to:  
  https://docs.hortonworks.com/HDPDocuments/Ambari-2.0.1.0/index.html ([https](https://docs.hortonworks.com/HDPDocuments/Ambari-2.0.1.0/index.html) result 200).
* [ ] http://kafka.apache.org/downloads.html with 1 occurrences migrated to:  
  https://kafka.apache.org/downloads.html ([https](https://kafka.apache.org/downloads.html) result 200).
* [ ] http://pivotalhd.docs.pivotal.io/docs/install-ambari.html with 4 occurrences migrated to:  
  https://pivotalhd.docs.pivotal.io/docs/install-ambari.html ([https](https://pivotalhd.docs.pivotal.io/docs/install-ambari.html) result 200).
* [ ] http://public-repo-1.hortonworks.com/ambari/centos6/1.x/updates/1.7.0/ambari.repo with 1 occurrences migrated to:  
  https://public-repo-1.hortonworks.com/ambari/centos6/1.x/updates/1.7.0/ambari.repo ([https](https://public-repo-1.hortonworks.com/ambari/centos6/1.x/updates/1.7.0/ambari.repo) result 200).
* [ ] http://public-repo-1.hortonworks.com/ambari/centos6/2.x/updates/2.0.1/ambari.repo with 1 occurrences migrated to:  
  https://public-repo-1.hortonworks.com/ambari/centos6/2.x/updates/2.0.1/ambari.repo ([https](https://public-repo-1.hortonworks.com/ambari/centos6/2.x/updates/2.0.1/ambari.repo) result 200).
* [ ] http://public-repo-1.hortonworks.com/ambari/centos6/2.x/updates/2.1.2.1/ambari.repo with 1 occurrences migrated to:  
  https://public-repo-1.hortonworks.com/ambari/centos6/2.x/updates/2.1.2.1/ambari.repo ([https](https://public-repo-1.hortonworks.com/ambari/centos6/2.x/updates/2.1.2.1/ambari.repo) result 200).
* [ ] http://redis.io/download with 1 occurrences migrated to:  
  https://redis.io/download ([https](https://redis.io/download) result 200).
* [ ] http://repo.spring.io/yum-release/spring-xd/1.3/ with 1 occurrences migrated to:  
  https://repo.spring.io/yum-release/spring-xd/1.3/ ([https](https://repo.spring.io/yum-release/spring-xd/1.3/) result 200).
* [ ] http://repo.spring.io/yum-release/spring-xd/1.3/spring-xd-1.3.repo with 2 occurrences migrated to:  
  https://repo.spring.io/yum-release/spring-xd/1.3/spring-xd-1.3.repo ([https](https://repo.spring.io/yum-release/spring-xd/1.3/spring-xd-1.3.repo) result 200).
* [ ] http://download.fedoraproject.org/pub/epel/6/i386/epel-release-6-8.noarch.rpm with 1 occurrences migrated to:  
  https://download.fedoraproject.org/pub/epel/6/i386/epel-release-6-8.noarch.rpm ([https](https://download.fedoraproject.org/pub/epel/6/i386/epel-release-6-8.noarch.rpm) result 302).